### PR TITLE
Normalize Name for Packagist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "Desire2Learn-Valence/valence-sdk-php",
+    "name": "desire2learn/valence-sdk-php",
     "description": "Desire2Learn Valence SDK for PHP",
     "keywords": ["d2l", "desire", "2", "learn", "api", "valence"],
     "license": "Apache-2.0",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "desire2learn/valence-sdk-php",
+    "name": "brightspace/valence-sdk-php",
     "description": "Desire2Learn Valence SDK for PHP",
     "keywords": ["d2l", "desire", "2", "learn", "api", "valence"],
     "license": "Apache-2.0",


### PR DESCRIPTION
Packagist error message:

> The package name Desire2Learn-Valence/valence-sdk-php is invalid, it should not contain uppercase characters. We suggest using desire2learn/valence-sdk-php instead.
